### PR TITLE
Fixed build error

### DIFF
--- a/aeryntests/test_func_test.cpp
+++ b/aeryntests/test_func_test.cpp
@@ -60,16 +60,6 @@ namespace Aeryn
 		{
 			return false;
 		}
-
-		/**	\brief Output operator for A.
-		 *
-		 *	\param os An output streem.
-		 *	\return os.
-		 */
-		std::ostream& operator<<( std::ostream& os, const A& )
-		{
-			return os;
-		}
 	}
 	
 	//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The build was not passing for me because it was erroring out due to
a compiler warning about an operator that was declared but not used.